### PR TITLE
Add a min-height to the label in .field-inputs

### DIFF
--- a/less/base/forms.less
+++ b/less/base/forms.less
@@ -198,6 +198,7 @@ a.button:active {
 .field-inputs label {
 	display: block;
 	margin: 0.4em;
+	min-height: 15px;
 }
 
 .field-inputs input[type="email"],


### PR DESCRIPTION
Checkboxes and radio buttons are put in the .field-inputs container as
with other form elements but since they are floated, they do not hold
open the container themselves. Rather, the text in the surrounding
label is used to hold open div.field-inputs and this is critical to
maintaining consistent spacing between the form elements.

```
 -------------   ------------------------
| Field label | | [] Checkbox label text |
 -------------   ------------------------
  ^-floated       ^- floated   ^- text holds open non-floated label

 -------------   ----
| Field label | | [] |
 -------------   ----
  ^- all the elements here are floated -
     nothing is holding the checkbox label
     open and this row collapses into the
     one beneath
```

By adding a min height to the label, it will act as if it has text
even if it is empty. The min-height has been chosen to match the
line-height value of 15px, as specified on the body.
