### PR TITLE
Add formstack interactives boot script to new boot_scripts directory

### DIFF
--- a/js/boot_scripts/formstack-interactive-boot.js
+++ b/js/boot_scripts/formstack-interactive-boot.js
@@ -96,7 +96,7 @@ define([], function () {
                             });
                             break;
                         default:
-                           console.error('Received unknown action from iframe: ', message);
+                           console && console.error && console.error('Received unknown action from iframe: ', message);
                     }
                 }, false);
 


### PR DESCRIPTION
This pull request creates a new js directory on pasteup called `boot_scripts` and adds the formstack interactives boot script to that directory. The purpose of this is to allow the script to be served via HTTPS on nextgen and r2.

cc @theefer 
