### PR TITLE
update last fonts to be protocol independent

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "pasteup",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": [
     "./js/modules/main.js",
     "./less/pasteup.less"

--- a/less/font-family/dw72-weekend-cond.less
+++ b/less/font-family/dw72-weekend-cond.less
@@ -1,10 +1,10 @@
 @font-face {
     font-family: "DW72 Weekend Cond";
-    src: url('http://pasteup.guim.co.uk/fonts/latin1/DW72-Weekend-Cond-Web-BL-Head.eot');
-    src: url('http://pasteup.guim.co.uk/fonts/latin1/DW72-Weekend-Cond-Web-BL-Head.eot?#iefix') format('embedded-opentype'),
-         url('http://pasteup.guim.co.uk/fonts/latin1/DW72-Weekend-Cond-Web-BL-Head.woff') format('woff'),
-         url('http://pasteup.guim.co.uk/fonts/latin1/DW72-Weekend-Cond-Web-BL-Head.ttf') format('truetype'),
-         url('http://pasteup.guim.co.uk/fonts/latin1/DW72-Weekend-Cond-Web-BL-Head.svg#GuardianTitlepieceWeb-Regular') format('svg');
+    src: url('//pasteup.guim.co.uk/fonts/latin1/DW72-Weekend-Cond-Web-BL-Head.eot');
+    src: url('//pasteup.guim.co.uk/fonts/latin1/DW72-Weekend-Cond-Web-BL-Head.eot?#iefix') format('embedded-opentype'),
+         url('//pasteup.guim.co.uk/fonts/latin1/DW72-Weekend-Cond-Web-BL-Head.woff') format('woff'),
+         url('//pasteup.guim.co.uk/fonts/latin1/DW72-Weekend-Cond-Web-BL-Head.ttf') format('truetype'),
+         url('//pasteup.guim.co.uk/fonts/latin1/DW72-Weekend-Cond-Web-BL-Head.svg#GuardianTitlepieceWeb-Regular') format('svg');
     font-weight: normal;
     font-style: normal;
     font-stretch: normal;


### PR DESCRIPTION
Following @sndrs changes (#29) there is still fonts loaded as http.