### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+### This project is now deprecated. Future development on the Guardian's design language can be found in [dotcom-rendering](https://github.com/guardian/dotcom-rendering/tree/master/packages/pasteup)
+
 Introduction
 ============
 


### PR DESCRIPTION
This incarnation of pasteup is no longer actively maintained. At one point, the frontend repo subsumed a [fork of pasteup](https://github.com/guardian/frontend/tree/master/static/src/stylesheets/pasteup), that has since been the source of truth for the Guardian design's language.

We are currently developing a [new version of Pasteup](https://github.com/guardian/dotcom-rendering/tree/master/packages/pasteup) using CSS-in-JS tokens, which will supersede this version and the version in the frontend repo. It will be published as version 1.0.0 on NPM (although not Bower).